### PR TITLE
chore(fonts): supprimer next/font/google pour build offline

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,7 +121,8 @@
 }
 
 body {
-	font-family: var(--font-sans);
+	font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+		"Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
 	background-color: white;
 	color: black;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,23 +1,16 @@
-import { Inter } from "next/font/google"
 import type React from "react"
 import "./globals.css"
 
-const inter = Inter({
-	subsets: ["latin"],
-	display: "swap",
-	variable: "--font-inter",
-})
-
-export default function RootLayout({
-	children,
+	export default function RootLayout({
+		children,
 }: {
-	children: React.ReactNode
+		children: React.ReactNode
 }) {
-	return (
-		<html lang="fr" className={`${inter.variable} antialiased`}>
-			<body className="bg-white text-black font-sans">{children}</body>
-		</html>
-	)
+		return (
+			<html lang="fr" className="antialiased">
+				<body className="bg-white text-black font-sans">{children}</body>
+			</html>
+		)
 }
 
 export const metadata = {


### PR DESCRIPTION
Objectif
- Construire sans accès externe (pas de Google Fonts).

Changements
- Retirer `next/font/google` et `Inter(...)` dans `app/layout.tsx`.
- Remplacer `className={`${inter.variable} antialiased`}` par `className="antialiased"`.
- Ajouter une pile système dans `app/globals.css` pour `body`.

Vérification
- `pnpm build` ne tente plus de contacter `fonts.googleapis.com`.